### PR TITLE
Django REST Framework compatibility

### DIFF
--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -170,6 +170,9 @@ class TestSerializer(unittest.TestCase):
         o = Obj(a=None)
         self.assertRaises(TypeError, lambda: ASerializer(o).data)
 
+    def test_error_on_data(self):
+        self.assertRaises(RuntimeError, lambda: Serializer(data='foo'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The change from `obj` -> `instance` wasn't necessary to be compatible with GETs in DRF generic views, but it brings the API closer to DRF serializers, so I think its a good change. Tried this out with some of the generic view tests in DRF, and seemed to work.

fixes #7 

@tomchristie how does this look?