### PR TITLE
Add label to control the key in the serialized output

### DIFF
--- a/serpy/fields.py
+++ b/serpy/fields.py
@@ -23,9 +23,10 @@ class Field(object):
     #: first argument. Otherwise, the object will be the only parameter.
     getter_takes_serializer = False
 
-    def __init__(self, attr=None, call=False, required=True):
+    def __init__(self, attr=None, call=False, label=None, required=True):
         self.attr = attr
         self.call = call
+        self.label = label
         self.required = required
 
     def to_value(self, value):

--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -17,7 +17,7 @@ def _compile_field_to_tuple(field, name, serializer_cls):
     if field._is_to_value_overridden():
         to_value = field.to_value
 
-    return (name, getter, to_value, field.call, field.required,
+    return (name, getter, to_value, field.call, field.required, field.label,
             field.getter_takes_serializer)
 
 
@@ -97,7 +97,7 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
 
     def _serialize(self, instance, fields):
         v = {}
-        for name, getter, to_value, call, required, pass_self in fields:
+        for name, getter, to_value, call, required, label, pass_self in fields:
             if pass_self:
                 result = getter(self, instance)
             else:
@@ -107,7 +107,7 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
                         result = result()
                     if to_value:
                         result = to_value(result)
-            v[name] = result
+            v[label or name] = result
 
         return v
 

--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -17,7 +17,7 @@ def _compile_field_to_tuple(field, name, serializer_cls):
     if field._is_to_value_overridden():
         to_value = field.to_value
 
-    # Set the field name to a supplied label; if none, set it to the attribute name.
+    # Set the field name to a supplied label; defaults to the attribute name.
     name = field.label or name
 
     return (name, getter, to_value, field.call, field.required,

--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -17,7 +17,10 @@ def _compile_field_to_tuple(field, name, serializer_cls):
     if field._is_to_value_overridden():
         to_value = field.to_value
 
-    return (name, getter, to_value, field.call, field.required, field.label,
+    # Set the field name to a supplied label; if none, set it to the attribute name.
+    name = field.label or name
+
+    return (name, getter, to_value, field.call, field.required,
             field.getter_takes_serializer)
 
 
@@ -97,7 +100,7 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
 
     def _serialize(self, instance, fields):
         v = {}
-        for name, getter, to_value, call, required, label, pass_self in fields:
+        for name, getter, to_value, call, required, pass_self in fields:
             if pass_self:
                 result = getter(self, instance)
             else:
@@ -107,7 +110,7 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
                         result = result()
                     if to_value:
                         result = to_value(result)
-            v[label or name] = result
+            v[name] = result
 
         return v
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -67,5 +67,10 @@ class TestFields(unittest.TestCase):
 
         self.assertTrue(MethodField.getter_takes_serializer)
 
+    def test_field_label(self):
+        field1 = StrField(label="@id")
+        self.assertEqual(field1.label, "@id")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -179,13 +179,15 @@ class TestSerializer(unittest.TestCase):
             content = MethodField(label="@content")
 
             def get_content(self, obj):
-                return "Hello World"
+                return obj.content
 
         o = Obj(context="http://foo/bar/baz/", content="http://baz/bar/foo/")
         data = ASerializer(o).data
 
         self.assertTrue("@context" in data)
+        self.assertEqual(data["@context"], "http://foo/bar/baz/")
         self.assertTrue("@content" in data)
+        self.assertEqual(data["@content"], "http://baz/bar/foo/")
 
 
 if __name__ == '__main__':

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -173,6 +173,20 @@ class TestSerializer(unittest.TestCase):
     def test_error_on_data(self):
         self.assertRaises(RuntimeError, lambda: Serializer(data='foo'))
 
+    def test_serializer_with_custom_output_label(self):
+        class ASerializer(Serializer):
+            context = StrField(label="@context")
+            content = MethodField(label="@content")
+
+            def get_content(self, obj):
+                return "Hello World"
+
+        o = Obj(context="http://foo/bar/baz/", content="http://baz/bar/foo/")
+        data = ASerializer(o).data
+
+        self.assertTrue("@context" in data)
+        self.assertTrue("@content" in data)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit adds an optional parameter, label, to a Field. When serialized, the serializer will use the label if it is defined, or it will default to using the attribute name as before.

This commit includes two new unit tests for this functionality.

Fixes #14