### PR TITLE
Omit key in output if required is false and value is none

### DIFF
--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -112,7 +112,13 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
                         result = result()
                     if to_value:
                         result = to_value(result)
-            v[name] = result
+
+            if required:
+                v[name] = result
+            elif not required and result:
+                v[name] = result
+            else:
+                continue
 
         return v
 

--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -113,12 +113,8 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
                     if to_value:
                         result = to_value(result)
 
-            if required:
+            if required or result is not None:
                 v[name] = result
-            elif not required and result:
-                v[name] = result
-            else:
-                continue
 
         return v
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -158,16 +158,21 @@ class TestSerializer(unittest.TestCase):
 
         o = Obj(a=None)
         data = ASerializer(o).data
-        self.assertEqual(data['a'], None)
+        # Tests that the key for a null value is not in the output
+        self.assertTrue('a' not in data)
 
         o = Obj(a='5')
         data = ASerializer(o).data
+        # Tests that the key on a non-required field with a value is in the output
         self.assertEqual(data['a'], 5)
 
+    def test_raises_for_type_coercion_on_none_value(self):
         class ASerializer(Serializer):
+            # Declare a required field
             a = IntField()
 
         o = Obj(a=None)
+        # Tests that a required field will raise an error if a None value is passed to it.
         self.assertRaises(TypeError, lambda: ASerializer(o).data)
 
     def test_error_on_data(self):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -177,16 +177,14 @@ class TestSerializer(unittest.TestCase):
         self.assertTrue('a' not in data)
 
         o = Obj()
-        with self.assertRaises(AttributeError):
-            BSerializer(o).data
+        self.assertRaises(AttributeError, lambda: BSerializer(o).data)
 
         d = {}
         data = CSerializer(d).data
         self.assertTrue('c' not in data)
 
         d = {}
-        with self.assertRaises(KeyError):
-            DSerializer(d).data
+        self.assertRaises(KeyError, lambda: DSerializer(d).data)
 
         o = Obj()
         data = ESerializer(o).data

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,5 +1,5 @@
 from .obj import Obj
-from serpy.fields import Field, MethodField, IntField, FloatField, StrField
+from serpy.fields import Field, MethodField, IntField, FloatField, StrField, BoolField
 from serpy.serializer import Serializer, DictSerializer
 import unittest
 
@@ -166,6 +166,25 @@ class TestSerializer(unittest.TestCase):
         # Tests that the key on a non-required field with a value
         # is in the output
         self.assertEqual(data['a'], 5)
+
+    def test_optional_field_falsy_values(self):
+        # Tests the interactions between falsy values (0 or "")
+        # and the required flag.
+        class ASerializer(Serializer):
+            a = IntField(required=False)
+            b = BoolField(required=False)
+            # Check the falsy values of empty strings and
+            # whether they pass as both required and non-required fields.
+            c = StrField()
+            d = StrField(required=False)
+
+        o = Obj(a=0, b=False, c="", d="")
+        data = ASerializer(o).data
+        self.assertTrue('a' in data)
+        self.assertTrue('b' in data)
+        # Empty strings should always appear in the output
+        self.assertTrue('c' in data)
+        self.assertTrue('d' in data)
 
     def test_raises_for_type_coercion_on_none_value(self):
         class ASerializer(Serializer):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -163,7 +163,8 @@ class TestSerializer(unittest.TestCase):
 
         o = Obj(a='5')
         data = ASerializer(o).data
-        # Tests that the key on a non-required field with a value is in the output
+        # Tests that the key on a non-required field with a value
+        # is in the output
         self.assertEqual(data['a'], 5)
 
     def test_raises_for_type_coercion_on_none_value(self):
@@ -172,7 +173,8 @@ class TestSerializer(unittest.TestCase):
             a = IntField()
 
         o = Obj(a=None)
-        # Tests that a required field will raise an error if a None value is passed to it.
+        # Tests that a required field will raise an error
+        # if a None value is passed to it.
         self.assertRaises(TypeError, lambda: ASerializer(o).data)
 
     def test_error_on_data(self):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -167,6 +167,9 @@ class TestSerializer(unittest.TestCase):
         class DSerializer(DictSerializer):
             d = IntField()
 
+        class ESerializer(Serializer):
+            e = CSerializer(required=False)
+
         o = Obj()
         data = ASerializer(o).data
         # Tests that a missing key is not reflected in the output
@@ -184,6 +187,9 @@ class TestSerializer(unittest.TestCase):
         d = {}
         with self.assertRaises(KeyError):
             DSerializer(d).data
+
+        o = Obj()
+        data = ESerializer(o).data
 
         o = Obj(a='5')
         data = ASerializer(o).data

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -156,10 +156,32 @@ class TestSerializer(unittest.TestCase):
         class ASerializer(Serializer):
             a = IntField(required=False)
 
-        o = Obj(a=None)
+        class BSerializer(Serializer):
+            b = IntField()
+
+        class CSerializer(DictSerializer):
+            c = IntField(required=False)
+
+        class DSerializer(DictSerializer):
+            d = IntField()
+
+        o = Obj()
         data = ASerializer(o).data
-        # Tests that the key for a null value is not in the output
+        # Tests that a missing key is not reflected in the output
+        # but with required=False does not raise an exception.
         self.assertTrue('a' not in data)
+
+        o = Obj()
+        with self.assertRaises(AttributeError):
+            BSerializer(o).data
+
+        d = {}
+        data = CSerializer(d).data
+        self.assertTrue('c' not in data)
+
+        d = {}
+        with self.assertRaises(KeyError):
+            DSerializer(d).data
 
         o = Obj(a='5')
         data = ASerializer(o).data

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,5 +1,7 @@
 from .obj import Obj
-from serpy.fields import Field, MethodField, IntField, FloatField, StrField, BoolField
+from serpy.fields import (
+    Field, MethodField, IntField, FloatField, StrField, BoolField
+)
 from serpy.serializer import Serializer, DictSerializer
 import unittest
 


### PR DESCRIPTION
In Django REST Framework, if a field is set to required=False and the value is None, the key will be omitted from the output.

Currently in serpy, if required is set to False and a value is null, the output will contain a null value for that key.

This commit changes the behaviour to match DRF. If a value is None and a key is set to required=False, the key will not appear in the output.

Includes an updated unit test to reflect this behaviour. A test case for type coercion on None values was also created to better reflect the code under test.
