### PR TITLE
Add a method for adding field after the definition of a serializer

### DIFF
--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -116,6 +116,19 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
 
         return v
 
+    @classmethod
+    def add_field(cls, name, field):
+        """
+        Add a field to the serializer, this is useful for handling circular
+        dependencies.
+        If a field with this name already exist nothing will be done.
+        """
+        if name in cls._field_map:
+            return
+        cls._field_map[name] = field
+        cls._compiled_fields = cls._compiled_fields \
+            + (_compile_field_to_tuple(field, name, cls),)
+
     def to_value(self, instance):
         fields = self._compiled_fields
         if self.many:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -189,6 +189,23 @@ class TestSerializer(unittest.TestCase):
         self.assertTrue("@content" in data)
         self.assertEqual(data["@content"], "http://baz/bar/foo/")
 
+    def test_add_field_simple(self):
+        class ASerializer(Serializer):
+            a = Field()
+        ASerializer.add_field('b', Field())
+
+        a = Obj(a=5, b=2)
+        self.assertEqual(ASerializer(a).data['a'], 5)
+        self.assertEqual(ASerializer(a).data['b'], 2)
+
+    def test_add_field_no_override(self):
+        class ASerializer(Serializer):
+            a = Field()
+        ASerializer.add_field('a', StrField())
+
+        a = Obj(a=5)
+        self.assertEqual(ASerializer(a).data['a'], 5)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It's useful in case of circular dependency.
Typically we have something like this:
```python
ASerilizer(Serializer):
    b = BSerializer(many=True)

BSerializer(Serializer):
    a = ASerializer(many=True)
```

This isn't possible in python because BSerializer isn't yet define when
we want to use it in ASerilizer. This Function give us the ability to
solve this problem this way:

```python
ASerilizer(Serializer):
    pass

BSerializer(Serializer):
    a = ASerializer(many=True)

ASerilizer.add_field('b', BSerializer(many=True)
```

Of course if the serialized objects reference themselves there will be
some infinite loop.

If this proposition is fine for you I could add some documentation about it.