### PR TITLE
Fix field 'required' behavior to match DRF

### DIFF
--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -107,12 +107,15 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
                 result = getter(self, instance)
             else:
                 result = getter(instance)
-                if required or result is not None:
-                    if call:
-                        result = result()
-                    if to_value:
-                        result = to_value(result)
-            v[name] = result
+            if required or result is not None:
+                if call:
+                    result = result()
+                if to_value:
+                    result = to_value(result)
+                if result is None and required:
+                    raise TypeError('Field {0} is required', name)
+                else:
+                    v[name] = result
 
         return v
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -158,7 +158,7 @@ class TestSerializer(unittest.TestCase):
 
         o = Obj(a=None)
         data = ASerializer(o).data
-        self.assertEqual(data['a'], None)
+        self.assertFalse('a' in data)
 
         o = Obj(a='5')
         data = ASerializer(o).data
@@ -166,6 +166,30 @@ class TestSerializer(unittest.TestCase):
 
         class ASerializer(Serializer):
             a = IntField()
+
+        o = Obj(a=None)
+        self.assertRaises(TypeError, lambda: ASerializer(o).data)
+
+    def test_optional_methodfield(self):
+        class ASerializer(Serializer):
+            a = MethodField(required=False)
+
+            def get_a(self, obj):
+                return obj.a
+
+        o = Obj(a=None)
+        data = ASerializer(o).data
+        self.assertFalse('a' in data)
+
+        o = Obj(a='5')
+        data = ASerializer(o).data
+        self.assertEqual(data['a'], '5')
+
+        class ASerializer(Serializer):
+            a = MethodField()
+
+            def get_a(self, obj):
+                return obj.a
 
         o = Obj(a=None)
         self.assertRaises(TypeError, lambda: ASerializer(o).data)


### PR DESCRIPTION
Non-required fields with None values are now omitted from the
serialization. Also required MethodFields with None value trigger
an exception now.