### PR TITLE
Pass a context in depth of serialize calls (API changed)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Complex Example
         x = serpy.Field(call=True)
         plus = serpy.MethodField()
 
-        def get_plus(self, obj):
+        def get_plus(self, obj, context):
             return obj.y + obj.z
 
     f = Foo()
@@ -169,6 +169,32 @@ Inheritance Example
     # {'a': 1}
     ABSerializer(f).data
     # {'a': 1, 'b': 2}
+
+Context Example
+---------------
+
+Context is just an object passed to each getter. It can be of any type.
+
+.. code-block:: python
+
+    import serpy
+
+    class ContextedField(serpy.Field):
+
+        def to_value(self, value, context):
+            return context.do_something(value)
+
+
+    class ASerializer(serpy.Serializer):
+        a = serpy.ContextedField()
+        b = serpy.MethodVield()
+
+        def get_b(self, value, context):
+            user = context.request.user
+            return value if user.is_authenticated else None
+
+    f = Foo()
+    ASerializer(f, context=context).data
 
 License
 =======

--- a/docs/custom-fields.rst
+++ b/docs/custom-fields.rst
@@ -10,7 +10,7 @@ adds 5 to every value it serializes, do:
 .. code-block:: python
 
    class Add5Field(serpy.Field):
-      def to_value(self, value):
+      def to_value(self, value, context):
          return value + 5
 
 Then to use it:
@@ -34,7 +34,7 @@ every serialized value has a ``'.'`` in it:
 .. code-block:: python
 
    class ValidateDotField(serpy.Field):
-      def to_value(self, value):
+      def to_value(self, value, context):
          if '.' not in value:
             raise ValidationError('no dot!')
          return value

--- a/serpy/fields.py
+++ b/serpy/fields.py
@@ -31,7 +31,7 @@ class Field(object):
         self.label = label
         self.required = required
 
-    def to_value(self, value):
+    def to_value(self, value, context):
         """Transform the serialized value.
 
         Override this method to clean and validate values serialized by this
@@ -41,6 +41,7 @@ class Field(object):
                 return int(value)
 
         :param value: The value fetched from the object being serialized.
+        :param context: A context received from caller.
         """
         return value
     to_value._serpy_base_implementation = True
@@ -78,22 +79,34 @@ class Field(object):
 
 class StrField(Field):
     """A :class:`Field` that converts the value to a string."""
-    to_value = staticmethod(six.text_type)
+
+    @staticmethod
+    def to_value(value, context):
+        return six.text_type(value)
 
 
 class IntField(Field):
     """A :class:`Field` that converts the value to an integer."""
-    to_value = staticmethod(int)
+
+    @staticmethod
+    def to_value(value, context):
+        return int(value)
 
 
 class FloatField(Field):
     """A :class:`Field` that converts the value to a float."""
-    to_value = staticmethod(float)
+
+    @staticmethod
+    def to_value(value, context):
+        return float(value)
 
 
 class BoolField(Field):
     """A :class:`Field` that converts the value to a boolean."""
-    to_value = staticmethod(bool)
+
+    @staticmethod
+    def to_value(value, context):
+        return bool(value)
 
 
 class MethodField(Field):
@@ -106,10 +119,10 @@ class MethodField(Field):
             plus = MethodField()
             minus = MethodField('do_minus')
 
-            def get_plus(self, foo_obj):
+            def get_plus(self, foo_obj, context):
                 return foo_obj.bar + foo_obj.baz
 
-            def do_minus(self, foo_obj):
+            def do_minus(self, foo_obj, context):
                 return foo_obj.bar - foo_obj.baz
 
         foo = Foo(bar=5, baz=10)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -7,16 +7,16 @@ import unittest
 class TestFields(unittest.TestCase):
 
     def test_to_value_noop(self):
-        self.assertEqual(Field().to_value(5), 5)
-        self.assertEqual(Field().to_value('a'), 'a')
-        self.assertEqual(Field().to_value(None), None)
+        self.assertEqual(Field().to_value(5, None), 5)
+        self.assertEqual(Field().to_value('a', None), 'a')
+        self.assertEqual(Field().to_value(None, None), None)
 
     def test_as_getter_none(self):
         self.assertEqual(Field().as_getter(None, None), None)
 
     def test_is_to_value_overridden(self):
         class TransField(Field):
-            def to_value(self, value):
+            def to_value(self, value, context):
                 return value
 
         field = Field()
@@ -28,26 +28,26 @@ class TestFields(unittest.TestCase):
 
     def test_str_field(self):
         field = StrField()
-        self.assertEqual(field.to_value('a'), 'a')
-        self.assertEqual(field.to_value(5), '5')
+        self.assertEqual(field.to_value('a', None), 'a')
+        self.assertEqual(field.to_value(5, None), '5')
 
     def test_bool_field(self):
         field = BoolField()
-        self.assertTrue(field.to_value(True))
-        self.assertFalse(field.to_value(False))
-        self.assertTrue(field.to_value(1))
-        self.assertFalse(field.to_value(0))
+        self.assertTrue(field.to_value(True, None))
+        self.assertFalse(field.to_value(False, None))
+        self.assertTrue(field.to_value(1, None))
+        self.assertFalse(field.to_value(0, None))
 
     def test_int_field(self):
         field = IntField()
-        self.assertEqual(field.to_value(5), 5)
-        self.assertEqual(field.to_value(5.4), 5)
-        self.assertEqual(field.to_value('5'), 5)
+        self.assertEqual(field.to_value(5, None), 5)
+        self.assertEqual(field.to_value(5.4, None), 5)
+        self.assertEqual(field.to_value('5', None), 5)
 
     def test_float_field(self):
         field = FloatField()
-        self.assertEqual(field.to_value(5.2), 5.2)
-        self.assertEqual(field.to_value('5.5'), 5.5)
+        self.assertEqual(field.to_value(5.2, None), 5.2)
+        self.assertEqual(field.to_value('5.5', None), 5.5)
 
     def test_method_field(self):
         class FakeSerializer(object):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -95,18 +95,20 @@ class TestSerializer(unittest.TestCase):
         self.assertEqual(BSerializer(b).data['b']['a'], 3)
 
     def test_serializer_method_field(self):
+        context = {5: 5, 9: 9}
+
         class ASerializer(Serializer):
             a = MethodField()
             b = MethodField('add_9')
 
-            def get_a(self, obj):
-                return obj.a + 5
+            def get_a(self, obj, context):
+                return obj.a + context[5]
 
-            def add_9(self, obj):
-                return obj.a + 9
+            def add_9(self, obj, context):
+                return obj.a + context[9]
 
         a = Obj(a=2)
-        data = ASerializer(a).data
+        data = ASerializer(a, context=context).data
         self.assertEqual(data['a'], 7)
         self.assertEqual(data['b'], 11)
 
@@ -142,7 +144,7 @@ class TestSerializer(unittest.TestCase):
 
     def test_custom_field(self):
         class Add5Field(Field):
-            def to_value(self, value):
+            def to_value(self, value, context):
                 return value + 5
 
         class ASerializer(Serializer):
@@ -178,7 +180,7 @@ class TestSerializer(unittest.TestCase):
             context = StrField(label="@context")
             content = MethodField(label="@content")
 
-            def get_content(self, obj):
+            def get_content(self, obj, context):
                 return obj.content
 
         o = Obj(context="http://foo/bar/baz/", content="http://baz/bar/foo/")


### PR DESCRIPTION
Currently serpy fields are both stateless and context-less, i.e. you can not access anything except the current value from inside of a serializers. While statelesness makes serpy fast and clear, there is no real reason not to pass context to lower levels of data serializers.

Most obvious use case: serialize URLs as absolute depending on a request.