### PR TITLE
Ordering

### DIFF
--- a/serpy/fields.py
+++ b/serpy/fields.py
@@ -2,6 +2,18 @@ import six
 import types
 
 
+class GlobalCounter(object):
+
+    _value = 0
+
+    @property
+    def value(self):
+        self._value += 1
+        return self._value
+
+global_counter = GlobalCounter()
+
+
 class Field(object):
     """:class:`Field` is used to define what attributes will be serialized.
 
@@ -30,6 +42,7 @@ class Field(object):
         self.call = call
         self.label = label
         self.required = required
+        self._creation_counter = global_counter.value
 
     def to_value(self, value):
         """Transform the serialized value.

--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -1,9 +1,11 @@
+from collections import OrderedDict
 from serpy.fields import Field
 import operator
 import six
 
 
 class SerializerBase(Field):
+
     _field_map = {}
 
 
@@ -28,7 +30,7 @@ class SerializerMeta(type):
 
     @staticmethod
     def _get_fields(direct_fields, serializer_cls):
-        field_map = {}
+        field_map = OrderedDict()
         # Get all the fields from base classes.
         for cls in serializer_cls.__mro__[::-1]:
             if issubclass(cls, SerializerBase):
@@ -52,6 +54,9 @@ class SerializerMeta(type):
                 direct_fields[attr_name] = field
         for k in direct_fields.keys():
             del attrs[k]
+
+        direct_fields = OrderedDict(sorted(direct_fields.items(),
+                                           key=lambda i: i[1]._creation_counter))
 
         real_cls = super(SerializerMeta, cls).__new__(cls, name, bases, attrs)
 
@@ -100,8 +105,8 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
         self.many = many
         self._data = None
 
-    def _serialize(self, instance, fields):
-        v = {}
+    def _serialize(self, instance, fields, context):
+        v = OrderedDict()
         for name, getter, to_value, call, required, pass_self in fields:
             if pass_self:
                 result = getter(self, instance)
@@ -133,6 +138,15 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
         if self._data is None:
             self._data = self.to_value(self.instance)
         return self._data
+
+    @classmethod
+    def sort_fields(cls, example):
+        def key_func(f):
+            if f[0] in example:
+                return example.index(f[0])
+            return len(cls._compiled_fields) + 1
+
+        cls._compiled_fields = tuple(sorted(cls._compiled_fields, key=key_func))
 
 
 class DictSerializer(Serializer):

--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -105,7 +105,7 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
         self.many = many
         self._data = None
 
-    def _serialize(self, instance, fields, context):
+    def _serialize(self, instance, fields):
         v = OrderedDict()
         for name, getter, to_value, call, required, pass_self in fields:
             if pass_self:


### PR DESCRIPTION
Ordering fields allows to have human-readable serialized data. It is also easy to compare and test while migrating from DRF.

Fields are ordered based on class hierarchy and creation time. Also added a function to set custom order for serialized fields.