### PR TITLE
Fixed: Missing field does not cause KeyError

### DIFF
--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -116,8 +116,8 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
                 if required:
                     raise TypeError('Field {0} is required', name)
                 # If the key raises an exception and it is not required,
-                # it is absent from the object. We can ignore it and continue to the next field.
-                # If it is required, this will raise the error.
+                # it is absent from the object. We can ignore it and continue to
+                # the next field. If it is required, this will raise the error.
                 continue
 
             if result is None:

--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -116,8 +116,9 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
                 if required:
                     raise TypeError('Field {0} is required', name)
                 # If the key raises an exception and it is not required,
-                # it is absent from the object. We can ignore it and continue to
-                # the next field. If it is required, this will raise the error.
+                # it is absent from the object. We can ignore it and continue
+                # to the next field. If it is required, this will raise
+                # the error.
                 continue
 
             if result is None:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -166,7 +166,7 @@ class TestSerializer(unittest.TestCase):
         data = ASerializer(o).data
         self.assertEqual(data['a'], 5)
         self.assertEqual(data['b'], 10)
-        # Check that an object value does not make it to the 
+        # Check that an object value does not make it to the
         # serialized value
         self.assertNotIn('x', data)
 


### PR DESCRIPTION
Previously, if an object was missing an attribute or key and it was not required it would raise an error in the serializer.

This commit changes the behaviour so that objects with non-required keys will be omitted from the output, while required keys will raise a TypeError.

This works for method fields as well:
 - If a method is not required, it will skip serializing this field in the object.
 - If it is required, but the return value is None it will also skip the field in the output.
 - If it is required and the object does not contain the attribute, it will raise a TypeError stating that this field is required.

Fixes #51 