### PR TITLE
Update MANIFEST.in to distribute license with src

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include DESCRIPTION.rst
+include LICENSE


### PR DESCRIPTION
Removes `description.rst` which looks to no longer exist and instead include the license file. 