### PR TITLE
Fix None not being supported as Field values

### DIFF
--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -106,18 +106,27 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
         v = {}
         for name, getter, to_value, call, required, pass_self in fields:
             if pass_self:
-                result = getter(self, instance)
+                try:
+                    result = getter(self, instance)
+                except (KeyError, AttributeError):
+                    if required:
+                        raise
+                    else:
+                        continue
             else:
-                result = getter(instance)
-            if required or result is not None:
-                if call:
-                    result = result()
-                if to_value:
-                    result = to_value(result)
-                if result is None and required:
-                    raise TypeError('Field {0} is required', name)
-                else:
-                    v[name] = result
+                try:
+                    result = getter(instance)
+                except (KeyError, AttributeError):
+                    if required:
+                        raise
+                    else:
+                        continue
+                if required or result is not None:
+                    if call:
+                        result = result()
+                    if to_value:
+                        result = to_value(result)
+            v[name] = result
 
         return v
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -152,13 +152,13 @@ class TestSerializer(unittest.TestCase):
         data = ASerializer(o).data
         self.assertEqual(data['a'], 15)
 
-    def test_optional_field(self):
+    def test_optional_intfield(self):
         class ASerializer(Serializer):
             a = IntField(required=False)
 
         o = Obj(a=None)
         data = ASerializer(o).data
-        self.assertNotIn('a', data)
+        self.assertIsNone(data['a'])
 
         o = Obj(a='5')
         data = ASerializer(o).data
@@ -171,6 +171,48 @@ class TestSerializer(unittest.TestCase):
         with self.assertRaises(TypeError):
             ASerializer(o).data
 
+    def test_optional_field_dictserializer(self):
+        class ASerializer(DictSerializer):
+            a = Field(required=False)
+
+        data = ASerializer({'a': None}).data
+        self.assertIsNone(data['a'])
+
+        data = ASerializer({}).data
+        self.assertNotIn('a', data)
+
+        class ASerializer(DictSerializer):
+            a = Field()
+
+        data = ASerializer({'a': None}).data
+        self.assertIsNone(data['a'])
+
+        with self.assertRaises(KeyError):
+            ASerializer({}).data
+
+    def test_optional_field(self):
+        class ASerializer(Serializer):
+            a = Field(required=False)
+
+        o = Obj(a=None)
+        data = ASerializer(o).data
+        self.assertIsNone(data['a'])
+
+        o = Obj()
+        data = ASerializer(o).data
+        self.assertNotIn('a', data)
+
+        class ASerializer(Serializer):
+            a = Field()
+
+        o = Obj(a=None)
+        data = ASerializer(o).data
+        self.assertIsNone(data['a'])
+
+        o = Obj()
+        with self.assertRaises(AttributeError):
+            ASerializer(o).data
+
     def test_optional_methodfield(self):
         class ASerializer(Serializer):
             a = MethodField(required=False)
@@ -180,7 +222,7 @@ class TestSerializer(unittest.TestCase):
 
         o = Obj(a=None)
         data = ASerializer(o).data
-        self.assertNotIn('a', data)
+        self.assertIsNone(data['a'])
 
         o = Obj(a='5')
         data = ASerializer(o).data
@@ -193,8 +235,8 @@ class TestSerializer(unittest.TestCase):
                 return obj.a
 
         o = Obj(a=None)
-        with self.assertRaises(TypeError):
-            ASerializer(o).data
+        data = ASerializer(o).data
+        self.assertIsNone(data['a'])
 
     def test_error_on_data(self):
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
Fixes #56 

This brings serpy more in line with DRF when encountering None values. For more info, see #56 

The behavior for serpy is now:

|  | `required=True` | `required=False` |
| --- | --- | --- |
| `data = {'value': 1}` |  `{'value': 1}` |  `{'value': 1}` |
| `data = {'value': None}` |  `{'value': None}` |  `{'value': None}` |
| `data = {}` |  `KeyError('value',)` |  `{}` |