### PR TITLE
serializer init add context

### DIFF
--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -101,6 +101,7 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
         self.instance = instance
         self.many = many
         self._data = None
+        self.context = context
 
     def _serialize(self, instance, fields):
         v = {}


### PR DESCRIPTION
Forgot to add context when serializer init