### PR TITLE
Return None if required=False

### DIFF
--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -114,7 +114,7 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
                     if required:
                         raise
                     else:
-                        continue
+                        result = None
                 if required or result is not None:
                     if call:
                         result = result()


### PR DESCRIPTION
I have a suggestion for how optional fields are returned when they are not included to a `DictSerializer`.  


| serpy 0.3.1          | required=True                      | required=False                                 |
| :--------------   | :----------------------- | :------------------------------------------ |
| `data = {'value': 1}`             | `{'value': 1}`               | `{'value': 1}`
| `data = {'value': None}`             | `{'value': None}`               | `{'value': None}`
| `data = {}`             | `KeyError(u"Got KeyError when....`               | `{}`


| Suggested          | required=True                      | required=False                                 |
| :--------------   | :----------------------- | :------------------------------------------ |
| `data = {'value': 1}`             | `{'value': 1}`               | `{'value': 1}`
| `data = {'value': None}`             | `{'value': None}`               | `{'value': None}`
| `data = {}`             | `KeyError(u"Got KeyError when....`               | `{'value': None}`

To me this makes more sense then excluding them from the dictionary serializers. Another option could also be to include a default property to fields. I think there should be "some" option for this regardless of the implementation.