### PR TITLE
Add support for DRF-like `Meta` classes inside custom serializer

### DIFF
--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -71,6 +71,7 @@ class SerializerMeta(type):
                     {
                         field.name: Field()
                         for field in model._meta.fields
+                        if field.name not in meta.exclude
                     }
                 )
             elif getattr(model, "__table__"):
@@ -79,6 +80,7 @@ class SerializerMeta(type):
                     {
                         field.name: Field()
                         for field in model.__table__.columns
+                        if field.name not in meta.exclude
                     }
                 )
             else:

--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -86,11 +86,11 @@ class SerializerMeta(type):
             exclude = getattr(meta, 'exclude', None)
             if not model:
                 raise RuntimeError(
-                    'If you specifiy a Meta class, you need to atleast specify a model'
+                    'If you specifiy a Meta class, you need to specify a model'
                 )
             if not fields and not exclude:
                 raise RuntimeError(
-                    'You need to specifiy either `fields` or `exclude` in your Meta class.'
+                    'You need to specifiy either `fields` or `exclude` in Meta'
                 )
             if fields and exclude:
                 raise RuntimeError(

--- a/serpy/serializer.py
+++ b/serpy/serializer.py
@@ -65,7 +65,7 @@ class SerializerMeta(type):
                 raise RuntimeError(
                     'If you specifiy a Meta class, you need to atleast specify a model'
                 )
-            if getattr(model, "_meta"):
+            if getattr(model, "_meta", None):
                 # Django models
                 direct_fields.update(
                     {
@@ -74,7 +74,7 @@ class SerializerMeta(type):
                         if field.name not in meta.exclude
                     }
                 )
-            elif getattr(model, "__table__"):
+            elif getattr(model, "__table__", None):
                 # SQLAlchemy model
                 direct_fields.update(
                     {


### PR DESCRIPTION
If pulled, this would extend serpy with the ability to accept a `Meta` class inside the custom serializer class.
The syntax for this class is heavily borrowed from DRF's ModelSerializer, e.g. it needs a model (either Django or SQLAlchemy) and an `exclude` or `fields` attribute which tell serpy which fields to exclude or include in the serialization.

This was inspired by the need to serialize a very big Django model but with greater speed than what DRF provides. However, this had the drawback of also needing to specifiy each field to be serialized in the Serializer, instead of just inserting a `Meta` class and be done.

I have done some basic benchmarks, this does not negatively impact the standard serialization speed, because of the top level `if meta:` statement, which will just skip the code if no `Meta` class is provided. If the class has been provided, the serialization speed doesn't suffer, at least on my machine. I have not conducted any kind of statistical benchmarking, just quick tests using the UNIX `time` utility.

I wanted to keep this code inside the SerializerMeta, so that the implicit fields are calculated at startup time, not at serialization time. This however means all serializers inheriting from `serpy.Serializer` will have this ability, not like DRF where only serializers inheriting from `rest_framework.serializers.ModelSerializer` will have this ability. 